### PR TITLE
Fix user program not printing output

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -280,6 +280,11 @@ void syscall_handler(struct registers *r) {
             r->eax = 0;
             break;
 
+        case 12: // sys_print(string)
+            print((const char*)r->ebx);
+            r->eax = 0;
+            break;
+
         default:
             print("Unknown syscall: ");
             int_to_chars(r->eax, buffer, sizeof(buffer));

--- a/syscalls/syscalls.h
+++ b/syscalls/syscalls.h
@@ -103,4 +103,13 @@ static inline int syscall_kill(int num, int arg1) {
     );
     return ret;
 }
+static inline int syscall_print(int num, const char* str) {
+    int ret;
+    asm volatile (
+        "int $0x80"
+        : "=a" (ret)
+        : "a" (num), "b" (str)
+    );
+    return ret;
+}
 #endif

--- a/userprog.c
+++ b/userprog.c
@@ -23,48 +23,62 @@ void user_program_main() {
     char read_buffer[128];
     int result;
 
+    // Print startup message
+    syscall_print(12, "=== User Program Starting ===\n");
+
     // Test 1: Write a file to the filesystem
     const char* test_file = "userspace.txt";
     const char* test_data = "Hello from user space!\n";
 
+    syscall_print(12, "Test 1: Writing file to filesystem...\n");
     result = syscall_file(2, test_file, test_data, str_len(test_data));
 
     // Test 2: Read the file back
+    syscall_print(12, "Test 2: Reading file back...\n");
     for (int i = 0; i < 128; i++) read_buffer[i] = 0;
     result = syscall_file(3, test_file, read_buffer, sizeof(read_buffer));
 
     // Test 3: Create another file
+    syscall_print(12, "Test 3: Creating another file...\n");
     const char* test_file2 = "document.txt";
     const char* doc_content = "This is a document created from user mode.\nIt demonstrates file system operations.\n";
 
     result = syscall_file(2, test_file2, doc_content, str_len(doc_content));
 
     // Test 4: Rename the second file
+    syscall_print(12, "Test 4: Renaming file...\n");
     const char* new_name = "renamed_doc.txt";
     result = syscall_rename(5, test_file2, new_name);
 
     // Test 5: Change file permissions
+    syscall_print(12, "Test 5: Changing file permissions...\n");
     result = syscall_chmod(7, test_file, 0x07);  // RWX permissions
 
     // Test 6: Test pipe creation
+    syscall_print(12, "Test 6: Creating pipe...\n");
     int pipe_fds[2];
     result = syscall_pipe(8, pipe_fds);
 
     // Test 7: Write to pipe (if pipe creation succeeded)
     if (result == 0) {
+        syscall_print(12, "Test 7: Pipe created successfully\n");
         const char* pipe_msg = "Pipe message from user space";
         // Note: pipe write uses special FD format, but we can demonstrate the syscall
     }
 
     // Test 8: Truncate a file
+    syscall_print(12, "Test 8: Truncating file...\n");
     result = syscall_truncate(6, test_file, 10);
 
     // Test 9: Create a final status file
+    syscall_print(12, "Test 9: Creating final status file...\n");
     const char* status_file = "user_status.txt";
     const char* status = "User space program completed successfully!\nAll system calls tested.\n";
     result = syscall_file(2, status_file, status, str_len(status));
 
     // Exit cleanly
+    syscall_print(12, "\n=== All tests completed! ===\n");
+    syscall_print(12, "User program exiting...\n");
     syscall_exit(1);
 
     // Should never reach here


### PR DESCRIPTION
The user program was not printing any output to the screen because there was no syscall for console output. This commit adds:

- sys_print syscall (syscall #12) in kernel syscall handler
- syscall_print wrapper function for user-space programs
- Print statements throughout user program to display test progress

User programs can now use syscall_print(12, "message") to output text to the VGA screen, making it visible what the program is doing.