### PR TITLE
Fix kernel to usermode switch failure

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -219,7 +219,7 @@ void switch_to_user_mode_with_task(int task_id) {
         "mov %0, %%eax\n"
         "pushl $0x23\n"         // User data segment selector
         "pushl %%eax\n"         // Stack pointer
-        "pushf\n"
+        "pushl $0x202\n"        // EFLAGS with IF=1 (bit 9) and reserved bit 1
         "pushl $0x1B\n"         // User code segment selector (RPL 3)
         "pushl %1\n"            // Instruction pointer
         "iret\n"


### PR DESCRIPTION
The switch_to_user_mode_with_task function was causing the system to hang because it disabled interrupts with 'cli' and then used 'pushf' to push the flags with IF=0. When 'iret' restored these flags, interrupts remained disabled in user mode.

Fixed by replacing 'pushf' with 'pushl $0x202' to push proper EFLAGS with the Interrupt Flag (bit 9) enabled and reserved bit 1 set. This ensures interrupts work correctly in user mode, allowing the system to respond to timer interrupts, keyboard input, and syscalls.